### PR TITLE
Bump actions to drop Node 20 deprecation warnings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,6 @@ jobs:
           git push origin $MAJOR --force
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Update major version tag
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
           - runner: macos-14
             platform: darwin-arm64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Create test project
         run: |
@@ -112,7 +112,7 @@ jobs:
   test-existing-bundle:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Create test project with pre-built bundle
         run: |

--- a/action.yml
+++ b/action.yml
@@ -70,19 +70,21 @@ runs:
   steps:
     - name: Setup Node.js
       if: inputs.build == 'true'
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: "22"
 
     - name: Setup Python
       if: inputs.build == 'true'
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ inputs.python-version }}
 
     - name: Install uv
       if: inputs.build == 'true'
-      uses: astral-sh/setup-uv@v4
+      # Pinned to a specific tag because setup-uv doesn't publish a floating
+      # `v8` major tag (verified 2026-05-06). Bump deliberately.
+      uses: astral-sh/setup-uv@v8.1.0
 
     - name: Install mcpb CLI
       if: inputs.build == 'true'


### PR DESCRIPTION
## Summary
GitHub started warning that Node 20 actions will stop running on the runner by **Sept 2026** (Node 24 becomes the default **June 2026**). Caught the warnings on synapse-research's v0.2.0 release run; the deprecated actions live in this composite action's transitive dependencies.

- `actions/setup-node` v4 → v6 (composite step)
- `actions/setup-python` v5 → v6 (composite step)
- `astral-sh/setup-uv` v4 → v8.1.0 (composite step; setup-uv doesn't publish a floating `v8` major tag — verified against their git refs, hence the explicit pin)
- `actions/checkout` v4 → v6 (across `release.yml` + `test.yml`)

## Test plan
- [x] Latest majors verified via `gh api repos/<owner>/<repo>/releases/latest`: setup-node v6.4.0, setup-python v6.2.0, setup-uv v8.1.0
- [ ] Push tag `v2.x` after merge so consumers using `mcpb-pack@v2` pick this up automatically
- [ ] Spot-check by tagging a follow-on patch release of synapse-research and confirming no Node 20 warnings appear in the run log