### PR TITLE
feat!: v3 — drop server.json handling, validate manifest.json instead

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           cat > manifest.json << 'EOF'
           {
-            "manifest_version": "0.3",
+            "manifest_version": "0.4",
             "name": "test/example",
             "version": "1.0.0",
             "description": "Test extension",
@@ -121,7 +121,7 @@ jobs:
 
           cat > manifest.json << 'EOF'
           {
-            "manifest_version": "0.3",
+            "manifest_version": "0.4",
             "name": "test/existing",
             "version": "2.0.0",
             "description": "Test existing bundle",
@@ -187,3 +187,140 @@ jobs:
           fi
 
           echo "All outputs verified successfully"
+
+  # Each case sets up a manifest that should fail validation, then runs
+  # the action with `continue-on-error: true` so the job sees the action
+  # exit non-zero. We assert outcome == 'failure' — a future regex/jq
+  # tweak that silently breaks the validation will turn the cell green
+  # (outcome 'success'), failing the matrix.
+  test-manifest-validation:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        case:
+          - name: missing-manifest
+            setup: |
+              # No manifest.json
+              echo "no manifest" > placeholder.txt
+          - name: invalid-json
+            setup: |
+              echo "{ this is not json" > manifest.json
+          - name: missing-manifest-version
+            setup: |
+              cat > manifest.json << 'EOF'
+              { "name": "x/y", "version": "1.0.0", "description": "d", "server": {} }
+              EOF
+          - name: missing-name
+            setup: |
+              cat > manifest.json << 'EOF'
+              { "manifest_version": "0.4", "version": "1.0.0", "description": "d", "server": {} }
+              EOF
+          - name: missing-version
+            setup: |
+              cat > manifest.json << 'EOF'
+              { "manifest_version": "0.4", "name": "x/y", "description": "d", "server": {} }
+              EOF
+          - name: missing-description
+            setup: |
+              cat > manifest.json << 'EOF'
+              { "manifest_version": "0.4", "name": "x/y", "version": "1.0.0", "server": {} }
+              EOF
+          - name: missing-server
+            setup: |
+              cat > manifest.json << 'EOF'
+              { "manifest_version": "0.4", "name": "x/y", "version": "1.0.0", "description": "d" }
+              EOF
+          - name: reverse-dns-no-slash
+            setup: |
+              cat > manifest.json << 'EOF'
+              {
+                "manifest_version": "0.4",
+                "name": "x/y",
+                "version": "1.0.0",
+                "description": "d",
+                "server": {},
+                "_meta": { "dev.mpak/registry": { "name": "no-slash" } }
+              }
+              EOF
+          - name: reverse-dns-too-short
+            setup: |
+              # Two chars: below the upstream minLength of 3
+              cat > manifest.json << 'EOF'
+              {
+                "manifest_version": "0.4",
+                "name": "x/y",
+                "version": "1.0.0",
+                "description": "d",
+                "server": {},
+                "_meta": { "dev.mpak/registry": { "name": "a/" } }
+              }
+              EOF
+          - name: reverse-dns-too-long
+            setup: |
+              # 250 chars: above the upstream maxLength of 200
+              LONG=$(printf 'a%.0s' {1..120})
+              cat > manifest.json <<EOF
+              {
+                "manifest_version": "0.4",
+                "name": "x/y",
+                "version": "1.0.0",
+                "description": "d",
+                "server": {},
+                "_meta": { "dev.mpak/registry": { "name": "${LONG}/${LONG}" } }
+              }
+              EOF
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up failing manifest case (${{ matrix.case.name }})
+        run: ${{ matrix.case.setup }}
+
+      - name: Run action — expect validation to fail
+        id: pack
+        uses: ./
+        continue-on-error: true
+        with:
+          build: false
+          upload: false
+          announce: false
+
+      - name: Assert validation rejected the manifest
+        run: |
+          if [ "${{ steps.pack.outcome }}" != "failure" ]; then
+            echo "::error::Expected the action to fail validation for case '${{ matrix.case.name }}', but outcome was '${{ steps.pack.outcome }}'"
+            exit 1
+          fi
+          echo "✓ Case '${{ matrix.case.name }}' correctly rejected"
+
+  # Happy-path validation: the optional reverse-DNS override is well-
+  # formed, action runs to completion (with build/upload/announce off
+  # so we only exercise validation).
+  test-manifest-validation-accepts-valid-reverse-dns:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up valid manifest with reverse-DNS override
+        run: |
+          cat > manifest.json << 'EOF'
+          {
+            "manifest_version": "0.4",
+            "name": "@nimblebraininc/example",
+            "version": "1.0.0",
+            "description": "d",
+            "server": {
+              "type": "python",
+              "entry_point": "server.py",
+              "mcp_config": { "command": "python", "args": ["server.py"] }
+            },
+            "_meta": { "dev.mpak/registry": { "name": "ai.nimblebrain/example" } }
+          }
+          EOF
+
+      - name: Run action — expect validation to pass
+        uses: ./
+        with:
+          build: false
+          upload: false
+          announce: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ Arch: x86_64 → x64, aarch64/arm64 → arm64
 git add . && git commit -m "..."
 git push origin main
 git tag vX.Y.Z && git push origin vX.Y.Z
-# Workflow auto-creates release and updates major tag (v2)
+# Workflow auto-creates release and updates the matching major tag (e.g. v3.1.0 bumps v3)
 ```
 
 ## Retry Pattern

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: NimbleBrainInc/mcpb-pack@v2
+      - uses: NimbleBrainInc/mcpb-pack@v3
 ```
 
 When you publish a GitHub release, this will:
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: NimbleBrainInc/mcpb-pack@v2
+      - uses: NimbleBrainInc/mcpb-pack@v3
 ```
 
 ### Multi-Platform
@@ -120,7 +120,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
-      - uses: NimbleBrainInc/mcpb-pack@v2
+      - uses: NimbleBrainInc/mcpb-pack@v3
         with:
           output: "{name}-{version}-${{ matrix.os }}-${{ matrix.arch }}.mcpb"
 ```
@@ -150,7 +150,7 @@ Each job builds and registers its own platform-specific bundle. The registry mer
 For CI validation or private servers:
 
 ```yaml
-- uses: NimbleBrainInc/mcpb-pack@v2
+- uses: NimbleBrainInc/mcpb-pack@v3
   with:
     upload: false
     announce: false
@@ -161,7 +161,7 @@ For CI validation or private servers:
 If you already build your `.mcpb` bundle separately (e.g., committed to the repo or built in a prior step), you can skip the build and just upload/announce:
 
 ```yaml
-- uses: NimbleBrainInc/mcpb-pack@v2
+- uses: NimbleBrainInc/mcpb-pack@v3
   with:
     directory: packages/mcp/mcpb
     bundle-path: context7.mcpb
@@ -180,7 +180,7 @@ The action will compute the SHA256 hash and size from the provided bundle, uploa
 For pure Node.js or Python servers without native dependencies, you can announce a single bundle as cross-platform using `any`:
 
 ```yaml
-- uses: NimbleBrainInc/mcpb-pack@v2
+- uses: NimbleBrainInc/mcpb-pack@v3
   with:
     platform-os: any
     platform-arch: any
@@ -212,7 +212,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: NimbleBrainInc/mcpb-pack@v2
+      - uses: NimbleBrainInc/mcpb-pack@v3
         with:
           build: ${{ inputs.build }}
           announce: ${{ inputs.announce }}
@@ -246,7 +246,6 @@ Then trigger manually from the Actions tab, checking out the release tag. The ac
 | `bundle-size`   | Size of the bundle in bytes        |
 | `bundle-sha256` | SHA256 hash for integrity checks   |
 | `announced`     | Whether registration succeeded     |
-| `server-json-found` | Whether a server.json was found and uploaded |
 
 ## Permissions
 
@@ -261,18 +260,18 @@ permissions:
 ### Building
 
 The action:
-1. Detects your server type from `manifest.json` (Python or Node.js)
-2. Vendors all dependencies into the bundle (Python: `deps/`, Node: `node_modules/`)
-3. Packages everything into a `.mcpb` file using the [mcpb CLI](https://github.com/anthropics/mcpb)
-4. If a `server.json` is present, validates it and syncs the version from `manifest.json`
+1. Validates `manifest.json` (mcpb v0.4 required fields, optional reverse-DNS name override)
+2. Detects your server type from `manifest.json` (Python or Node.js)
+3. Vendors all dependencies into the bundle (Python: `deps/`, Node: `node_modules/`)
+4. Packages everything into a `.mcpb` file using the [mcpb CLI](https://github.com/anthropics/mcpb)
 
 ### Announcing
 
 When you announce to mpak.dev:
-1. The action uploads the `.mcpb` bundle (and `server.json`, if present) to the GitHub release
+1. The action uploads the `.mcpb` bundle to the GitHub release
 2. The action requests an [OIDC token](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect) from GitHub
 3. This token cryptographically proves the bundle came from your repository
-4. The registry verifies the token, registers your bundle, and fetches any `server.json` from the release
+4. The registry verifies the token and registers your bundle; the registry composes the MCP `ServerDetail` discovery shape from your `manifest.json`
 5. No API keys or secrets needed
 
 Each platform build announces its own artifact. The registry tracks all artifacts for a version, so users can install the right bundle for their system.
@@ -282,7 +281,7 @@ Each platform build announces its own artifact. The registry tracks all artifact
 To build without publishing to the public registry:
 
 ```yaml
-- uses: NimbleBrainInc/mcpb-pack@v2
+- uses: NimbleBrainInc/mcpb-pack@v3
   with:
     announce: false
 ```
@@ -293,58 +292,48 @@ You might want this if:
 - You want to test before publishing
 - You distribute through other channels
 
-## MCP Registry Discovery (server.json)
+## MCP Registry Discovery
 
-You can include a `server.json` file in your repository to make your MCP server discoverable through the [MCP Registry](https://registry.mpak.dev). This file provides metadata that the registry uses to list your server in its discovery API (`/v0.1/servers`).
+mpak automatically composes the MCP Registry's [`ServerDetail`](https://github.com/modelcontextprotocol/registry/blob/main/docs/reference/server-json/draft/server.schema.json) discovery shape from your bundle's `manifest.json` — there is no separate `server.json` file to maintain. Every announced bundle is reachable at:
 
-### Why add a server.json?
+- `GET /v1/servers/<your-name>` — latest `ServerDetail`
+- `GET /v1/servers/<your-name>/versions/<version>` — version-specific
+- `GET /v1/servers/search?q=...` — paginated search
 
-Without `server.json`, your bundle is published to mpak and installable via `mpak bundle pull`, but it won't appear in MCP Registry discovery endpoints. Adding `server.json` makes your server findable by AI clients and tools that query the registry.
+### Naming
 
-### Minimal server.json
+By default the registry assigns a reverse-DNS name mechanically from your npm-style package name:
 
-Only `name` and `description` are required:
+- `@your-org/your-server` → `dev.mpak.your-org/your-server`
 
-```json
-{
-  "name": "@your-org/your-server",
-  "description": "What your server does"
-}
-```
-
-The `version` is automatically synced from your `manifest.json` at build time.
-
-### Full example
+If you want a branded reverse-DNS name (e.g. `com.example/your-server`), set it in your manifest's `_meta`:
 
 ```json
 {
+  "manifest_version": "0.4",
   "name": "@your-org/your-server",
+  "version": "1.0.0",
   "description": "What your server does",
-  "title": "Human-Friendly Server Name",
-  "repository": {
-    "url": "https://github.com/your-org/your-repo",
-    "source": "https://github.com/your-org/your-repo"
+  "_meta": {
+    "dev.mpak/registry": {
+      "name": "com.example/your-server"
+    }
   }
 }
 ```
 
-| Field | Required | Description |
-|-------|----------|-------------|
-| `name` | Yes | Package name (must match `manifest.json`) |
-| `description` | Yes | Short description of the server |
-| `version` | No | Synced automatically from `manifest.json` |
-| `title` | No | Human-friendly display name |
-| `repository` | No | Source repository URLs |
-| `packages` | No | Populated automatically by the registry with bundle download info |
+The override must match the upstream pattern `^[a-zA-Z0-9.-]+/[a-zA-Z0-9._-]+$` (one slash separating the reverse-DNS namespace from the server name).
 
-### What happens at build time
+### Migration from `server.json` (v2 → v3)
 
-1. The action validates `server.json` (checks valid JSON, required fields)
-2. Syncs the `version` field from `manifest.json` into `server.json`
-3. Uploads `server.json` as a release asset alongside the `.mcpb` bundle
-4. When the registry processes the announce, it fetches `server.json` from the release and stores the metadata
+If you previously shipped a `server.json` file alongside your bundle, you can delete it. Versions of this action prior to `v3` validated and uploaded `server.json` to the GitHub release; `v3` no longer reads or uploads it. The registry composes the `ServerDetail` discovery shape from `manifest.json` instead.
 
-The `packages[]` array in the registry response is populated automatically from announced bundles. You don't need to include it in your `server.json`.
+```bash
+git rm server.json
+# Optional: add a reverse-DNS name override to manifest.json (see "Naming" above).
+git add manifest.json
+git commit -m "drop server.json (mcpb-pack@v3 composes registry metadata from manifest)"
+```
 
 ## Supported Runtimes
 
@@ -389,7 +378,7 @@ jobs:
           mkdir -p bin
           go build -o bin/server ./cmd/server
 
-      - uses: NimbleBrainInc/mcpb-pack@v2
+      - uses: NimbleBrainInc/mcpb-pack@v3
         with:
           output: "{name}-{version}-${{ matrix.os }}-${{ matrix.arch }}.mcpb"
 ```

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Your repository needs:
 
 ```json
 {
+  "manifest_version": "0.4",
   "name": "@your-github-org/your-server",
   "version": "1.0.0",
   "description": "What your server does",

--- a/action.yml
+++ b/action.yml
@@ -61,9 +61,6 @@ outputs:
   announced:
     description: "Whether the bundle was announced successfully"
     value: ${{ steps.announce.outputs.announced }}
-  server-json-found:
-    description: "Whether a server.json was found and included in the release"
-    value: ${{ steps.server-json.outputs.found }}
 
 runs:
   using: "composite"
@@ -177,46 +174,47 @@ runs:
         echo "Using existing bundle: $BUNDLE ($(du -h "$BUNDLE" | cut -f1))"
         echo "SHA256: $SHA256"
 
-    - name: Validate & prepare server.json
-      id: server-json
+    - name: Validate manifest.json
+      id: manifest
       shell: bash
       run: |
         cd "${{ inputs.directory }}"
 
-        if [ ! -f "server.json" ]; then
-          echo "No server.json found, skipping MCP Registry discovery metadata"
-          echo "found=false" >> $GITHUB_OUTPUT
-          exit 0
-        fi
-
-        echo "found=true" >> $GITHUB_OUTPUT
-
-        # Validate it's valid JSON
-        if ! jq empty server.json 2>/dev/null; then
-          echo "::error::server.json is not valid JSON"
+        if [ ! -f "manifest.json" ]; then
+          echo "::error::manifest.json not found in ${{ inputs.directory }}"
           exit 1
         fi
 
-        # Validate required fields (name, description, version per MCP Registry spec)
-        NAME=$(jq -r '.name // empty' server.json)
-        DESC=$(jq -r '.description // empty' server.json)
-
-        if [ -z "$NAME" ]; then
-          echo "::error::server.json missing required field: name"
+        # Valid JSON?
+        if ! jq empty manifest.json 2>/dev/null; then
+          echo "::error::manifest.json is not valid JSON"
           exit 1
         fi
 
-        if [ -z "$DESC" ]; then
-          echo "::error::server.json missing required field: description"
-          exit 1
+        # Required mcpb v0.4 fields.
+        for field in manifest_version name version description server; do
+          VALUE=$(jq -r ".${field} // empty" manifest.json)
+          if [ -z "$VALUE" ]; then
+            echo "::error::manifest.json missing required field: ${field}"
+            exit 1
+          fi
+        done
+
+        # Optional reverse-DNS name override per the MCP registry naming
+        # convention. When set it must contain exactly one slash and only
+        # the characters the upstream pattern allows. Anything else is
+        # rejected here so a malformed override doesn't silently fall
+        # back to the registry's mechanical default.
+        REVERSE_DNS=$(jq -r '._meta["dev.mpak/registry"].name // empty' manifest.json)
+        if [ -n "$REVERSE_DNS" ]; then
+          if ! echo "$REVERSE_DNS" | grep -Eq '^[a-zA-Z0-9.-]+/[a-zA-Z0-9._-]+$'; then
+            echo "::error::manifest._meta[\"dev.mpak/registry\"].name must match ^[a-zA-Z0-9.-]+/[a-zA-Z0-9._-]+$ (got: $REVERSE_DNS)"
+            exit 1
+          fi
+          echo "Reverse-DNS name override: $REVERSE_DNS"
         fi
 
-        # Sync version from manifest.json into server.json (single source of truth)
-        MANIFEST_VERSION=$(jq -r '.version // "0.0.0"' manifest.json)
-        jq --arg v "$MANIFEST_VERSION" '.version = $v' server.json > server.json.tmp && mv server.json.tmp server.json
-
-        echo "server.json validated (name=$NAME, version=$MANIFEST_VERSION)"
-        echo "path=server.json" >> $GITHUB_OUTPUT
+        echo "manifest.json validated"
 
     - name: Upload to release
       id: upload
@@ -231,12 +229,6 @@ runs:
 
         echo "Uploading $BUNDLE_PATH to release $TAG"
         gh release upload "$TAG" "$BUNDLE_PATH" --clobber
-
-        # Upload server.json if present (identical across platform jobs, so ignore if already uploaded)
-        if [ "${{ steps.server-json.outputs.found }}" = "true" ]; then
-          echo "Uploading server.json to release $TAG"
-          gh release upload "$TAG" server.json 2>&1 || echo "server.json already uploaded by another job, skipping"
-        fi
 
         echo "uploaded=true" >> $GITHUB_OUTPUT
 

--- a/action.yml
+++ b/action.yml
@@ -65,6 +65,61 @@ outputs:
 runs:
   using: "composite"
   steps:
+    # Validate first — manifest is mandatory and the rest of the pipeline
+    # reads from it. Failing here saves a 30s+ Python `uv pip install`
+    # vendor step on a broken manifest.
+    - name: Validate manifest.json
+      id: manifest
+      shell: bash
+      run: |
+        cd "${{ inputs.directory }}"
+
+        if [ ! -f "manifest.json" ]; then
+          echo "::error::manifest.json not found in ${{ inputs.directory }}"
+          exit 1
+        fi
+
+        # Valid JSON?
+        if ! jq empty manifest.json 2>/dev/null; then
+          echo "::error::manifest.json is not valid JSON"
+          exit 1
+        fi
+
+        # Required mcpb v0.4 fields. v0.3 is also accepted (the required
+        # set is identical; v0.4 only added the "uv" server.type and the
+        # `icons[]` array).
+        for field in manifest_version name version description server; do
+          VALUE=$(jq -r ".${field} // empty" manifest.json)
+          if [ -z "$VALUE" ]; then
+            echo "::error::manifest.json missing required field: ${field}"
+            exit 1
+          fi
+        done
+
+        # Optional reverse-DNS name override per the MCP registry naming
+        # convention. Validated against the upstream `name` constraints:
+        # one-slash reverse-DNS pattern + 3..200 char length bound.
+        # Catching it here keeps the registry's announce-time error
+        # message ("invalid name") from being the operator's first
+        # signal of a typo.
+        # Defensive jq access: tolerates a `_meta` key that's set but
+        # not an object (legal JSON, would otherwise error in jq).
+        REVERSE_DNS=$(jq -r '.["_meta"]?["dev.mpak/registry"]?.name // empty' manifest.json)
+        if [ -n "$REVERSE_DNS" ]; then
+          if ! echo "$REVERSE_DNS" | grep -Eq '^[a-zA-Z0-9.-]+/[a-zA-Z0-9._-]+$'; then
+            echo "::error::manifest._meta[\"dev.mpak/registry\"].name must match ^[a-zA-Z0-9.-]+/[a-zA-Z0-9._-]+$ (got: $REVERSE_DNS)"
+            exit 1
+          fi
+          LEN=${#REVERSE_DNS}
+          if [ "$LEN" -lt 3 ] || [ "$LEN" -gt 200 ]; then
+            echo "::error::manifest._meta[\"dev.mpak/registry\"].name length must be 3..200 chars (got: $LEN)"
+            exit 1
+          fi
+          echo "Reverse-DNS name override: $REVERSE_DNS"
+        fi
+
+        echo "manifest.json validated"
+
     - name: Setup Node.js
       if: inputs.build == 'true'
       uses: actions/setup-node@v6
@@ -173,48 +228,6 @@ runs:
         echo "sha256=$SHA256" >> $GITHUB_OUTPUT
         echo "Using existing bundle: $BUNDLE ($(du -h "$BUNDLE" | cut -f1))"
         echo "SHA256: $SHA256"
-
-    - name: Validate manifest.json
-      id: manifest
-      shell: bash
-      run: |
-        cd "${{ inputs.directory }}"
-
-        if [ ! -f "manifest.json" ]; then
-          echo "::error::manifest.json not found in ${{ inputs.directory }}"
-          exit 1
-        fi
-
-        # Valid JSON?
-        if ! jq empty manifest.json 2>/dev/null; then
-          echo "::error::manifest.json is not valid JSON"
-          exit 1
-        fi
-
-        # Required mcpb v0.4 fields.
-        for field in manifest_version name version description server; do
-          VALUE=$(jq -r ".${field} // empty" manifest.json)
-          if [ -z "$VALUE" ]; then
-            echo "::error::manifest.json missing required field: ${field}"
-            exit 1
-          fi
-        done
-
-        # Optional reverse-DNS name override per the MCP registry naming
-        # convention. When set it must contain exactly one slash and only
-        # the characters the upstream pattern allows. Anything else is
-        # rejected here so a malformed override doesn't silently fall
-        # back to the registry's mechanical default.
-        REVERSE_DNS=$(jq -r '._meta["dev.mpak/registry"].name // empty' manifest.json)
-        if [ -n "$REVERSE_DNS" ]; then
-          if ! echo "$REVERSE_DNS" | grep -Eq '^[a-zA-Z0-9.-]+/[a-zA-Z0-9._-]+$'; then
-            echo "::error::manifest._meta[\"dev.mpak/registry\"].name must match ^[a-zA-Z0-9.-]+/[a-zA-Z0-9._-]+$ (got: $REVERSE_DNS)"
-            exit 1
-          fi
-          echo "Reverse-DNS name override: $REVERSE_DNS"
-        fi
-
-        echo "manifest.json validated"
 
     - name: Upload to release
       id: upload


### PR DESCRIPTION
## Summary

- Stop treating \`server.json\` as an authoring surface. The mpak registry composes its \`ServerDetail\` discovery shape from each bundle's \`manifest.json\` server-side, so the per-bundle \`server.json\` file (and this action's validate-and-upload step for it) is no longer useful.
- Replace the old \"Validate & prepare server.json\" step with a new \"Validate manifest.json\" step that checks the mcpb v0.4 required fields and, when present, validates the optional reverse-DNS name override at \`manifest._meta[\"dev.mpak/registry\"].name\`.
- Cut as **v3** so bundles upgrade explicitly.

## Breaking changes

- Removed the \`Validate & prepare server.json\` step.
- Removed the \`server-json-found\` action output.
- The action no longer uploads \`server.json\` to the GitHub release. Bundles that still ship a \`server.json\` file in their repo are unaffected at build time but should drop it as part of upgrading to \`@v3\`.

## Compatibility

- Bundles on \`@v2\` keep working — the registry already ignores \`server.json\` files in releases (the \`ServerDetail\` it serves is composed from \`manifest.json\`).
- New bundles or version bumps should adopt \`@v3\` at their own pace.

## Migration for bundle authors (one-liner)

\`\`\`bash
git rm server.json
# Optional: add a branded reverse-DNS name override to manifest.json
#   \"_meta\": { \"dev.mpak/registry\": { \"name\": \"com.example/your-server\" } }
git add manifest.json
git commit -m \"drop server.json (mcpb-pack@v3 composes registry metadata from manifest)\"
\`\`\`

Then bump the action ref in \`.github/workflows/release.yml\`:

\`\`\`yaml
- uses: NimbleBrainInc/mcpb-pack@v3
\`\`\`

## Test plan

- [x] Workflow YAML syntactically valid (no \`server.json\` step references remain in \`action.yml\`)
- [x] README examples bumped to \`@v3\` (10 occurrences updated, 0 \`@v2\` remaining)
- [x] Manifest validation step rejects: missing \`manifest.json\`, invalid JSON, missing required fields (\`manifest_version\`, \`name\`, \`version\`, \`description\`, \`server\`), malformed reverse-DNS override
- [ ] Cut \`v3.0.0\` tag after merge to fire the release workflow + update the \`v3\` major tag